### PR TITLE
serve /v2* and /api* from python app

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -20,6 +20,12 @@
 	    respond "ok {$GIT_SHA}" 200
     }
 
+    handle /api* {
+        reverse_proxy localhost:8888 {
+          trusted_proxies private_ranges
+        }
+    }
+
     handle /v2* {
         reverse_proxy localhost:8888 {
           trusted_proxies private_ranges

--- a/Caddyfile.dev.json
+++ b/Caddyfile.dev.json
@@ -36,6 +36,24 @@
           "listen": [":8889", "localhost:8890"],
           "routes": [
             {
+              "match": [{ "path": ["/api*"] }],
+              "handle": [
+                {
+                  "handler": "subroute",
+                  "routes": [
+                    {
+                      "handle": [
+                        {
+                          "handler": "reverse_proxy",
+                          "upstreams": [{ "dial": "localhost:8888" }]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
               "match": [{ "path": ["/v2*"] }],
               "handle": [
                 {


### PR DESCRIPTION
Only affects Codespaces currently, similar changes may be required to the Ingress configuration as a part of https://linear.app/cased/issue/CAS-455.