### PR TITLE
Add workflow triggers to enable GitHub Merge Queue

### DIFF
--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - gh-readonly-queue/main/*
   pull_request:
     types:
       - opened
@@ -110,6 +111,7 @@ jobs:
     # changes.
     if: |
       github.ref == format('refs/heads/{0}', github.event.repository.default_branch) ||
+      contains(github.ref, format('gh-readonly-queue/{0}/', github.event.repository.default_branch)) ||
       needs.lint.outputs.changed == 'true'
     strategy:
       fail-fast: false

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+      - gh-readonly-queue/main/*
   # Build and push images on PRs with the docker:pr-image label
   pull_request:
     types:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,6 +12,7 @@ on:
   push:
     branches:
       - main
+      - gh-readonly-queue/main/*
     # Build and push cased/shell:vX.X.X images on push to tags matching vX.X.X
     tags:
       - v*
@@ -168,4 +169,3 @@ jobs:
             type=gha,scope=${{ matrix.image.name }}-${{ github.ref_name }}
           cache-to: |
             type=registry,ref=ghcr.io/cased/${{ matrix.image.name }}-cache:${{ github.event.number == 0 && (startsWith(github.ref, 'refs/tags/') && 'latest' || github.event.repository.default_branch) || format('pr-{0}', github.event.number) }},mode=max
-

--- a/.github/workflows/frontend-code-quality.yml
+++ b/.github/workflows/frontend-code-quality.yml
@@ -1,5 +1,6 @@
 name: Frontend Code Quality Check - Required
 on:
+  merge_group:
   pull_request:
     types:
       - opened

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - gh-readonly-queue/main/*
   pull_request:
     types:
       - opened


### PR DESCRIPTION
The new [GitHub Merge Queue](https://github.blog/changelog/2023-02-08-pull-request-merge-queue-public-beta/) is designed to let computers handle the chore of validating and merging approved PRs that have fallen behind the base branch. PRs now present a call-to-action of 'Merge when ready' that does, well, what you want it to do.

![](https://i0.wp.com/user-images.githubusercontent.com/2503052/217023882-cf4bf568-af5d-469e-882a-14f1837add72.gif?ssl=1)

This Pull Request configures all of the following builds to run when a pull request is submitted to the merge queue:

https://github.com/cased/shell/blob/1ef3176a7bffee6d7672880c6071e73f75f802ae/.github/workflows/required.yml#L9-L13


### Resources

- https://github.com/community/community/discussions/46757
- https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue

### Meta

Due to [a bug](https://github.com/community/community/discussions/46757#discussioncomment-4909983) we configure workflows to run on `push` events with branches matching `github-readonly-queue/main/*` as well as the `merge_group` event.