### PR TITLE
Don't build arm64 Docker images by default

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -48,21 +48,19 @@ jobs:
             context: ./
             dockerfile: Dockerfile
             vuln-type: os,library
-            # Skip linux/arm64/v8 for now as it takes 1h+ and is not required for M1/M2 Mac OS VS Code usage
-            # Also https://support.github.com/ticket/personal/0/1858013 causes regular failures
             platforms: linux/amd64
           - name: sshd-demo
             context: .devcontainer/sshd
             dockerfile: .devcontainer/sshd/Dockerfile
             vuln-type: os,library
-            platforms: linux/amd64,linux/arm64/v8
+            platforms: linux/amd64
           - name: shell-devcontainer
             context: ./
             dockerfile: .devcontainer/Dockerfile
             # TODO
             # vuln-type: os,library
             vuln-type: os
-            platforms: linux/amd64,linux/arm64/v8
+            platforms: linux/amd64
             args: |
               NODE_VERSION=lts/*
 


### PR DESCRIPTION
These builds are too slow on the default Actions runners that we're constrained to now that the repo is public. Local devcontainers can still be started and built on M1/M2 Macs, they will just be slower to start.