### PR TITLE
Don't skip 'Required' build during merge queue workflow

### DIFF
--- a/.github/workflows/required.yml
+++ b/.github/workflows/required.yml
@@ -16,7 +16,10 @@ on:
 
 jobs:
   success:
-    if: github.event.workflow_run.event == 'pull_request'
+    if: |
+      github.event.workflow_run.event == 'pull_request' ||
+      github.event.workflow_run.event == 'push' ||
+      github.event.workflow_run.event == 'merge_group'
     name: Create appropriate status
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
https://github.com/cased/shell/actions/runs/4168278502 should not have been skipped; it should have instead been run to denote https://github.com/cased/shell/pull/34 as ready to merge. Sorry @ashblue!